### PR TITLE
'SESSION_REDIRECT_ON_REGISTER' => true,

### DIFF
--- a/src/Auth/Core.php
+++ b/src/Auth/Core.php
@@ -49,6 +49,7 @@ class Core
         'TOKEN_LIFETIME' => null,
         'TOKEN_SECRET' => '@_leaf$0Secret!',
         'SESSION_REDIRECT_ON_LOGIN' => true,
+        'SESSION_REDIRECT_ON_REGISTER' => true,
         'SESSION_LIFETIME' => self::TIMESTAMP_OF_ONE_DAY,
         'SESSION_COOKIE_PARAMS' => ['secure' => true, 'httponly' => true, 'samesite' => 'lax'],
     ];


### PR DESCRIPTION
On registration i wish to send activation emails and other jobs then i will do manually redirect to login with proper message. Now we are automatically redirected so i cant do housekeeping right :)